### PR TITLE
Preserve ICC profile while stripping extra metadata

### DIFF
--- a/src/Deepzoom.php
+++ b/src/Deepzoom.php
@@ -257,8 +257,12 @@ class Deepzoom
             case 'Imagick':
                 $image = new \Imagick();
                 $image->readImage($this->filepath);
+                $profiles = $image->getImageProfiles("icc", true);
                 $image->transformImageColorspace(\Imagick::COLORSPACE_SRGB);
                 $image->stripImage();
+                if(!empty($profiles)) {
+                    $image->profileImage("icc", $profiles['icc']);
+                }
                 break;
             case 'GD':
                 $image = $this->openImage();


### PR DESCRIPTION
During the tiling process, ICC profiles are being stripped out while using GD and PHP Imagick. This can cause washed out colors on the tiled images compared to the original and other static derivatives. The command line version of ImageMagick is un-affected by this issue, but is slow and resource intensive.

As far as my research has gone GD doesn't offer a solution for this, however PHP Imagick has a solution documented here: https://www.php.net/manual/en/imagick.stripimage.php#120380

This PR is an implementation of that solution and resolves the problem for Imagick, which is a step in the right direction.